### PR TITLE
File System Initialisation

### DIFF
--- a/Kernel/Kernel/Tasks/IdleTask.cs
+++ b/Kernel/Kernel/Tasks/IdleTask.cs
@@ -49,10 +49,10 @@ namespace Kernel.Tasks
             while (!Terminating)
             {
                 *((ushort*)0xB809E) = (0x1F00 | '1');
-                TheCPU?.Halt();
+                TheCPU.Halt();
 
                 *((ushort*)0xB809E) = (0x3F00 | '2');
-                TheCPU?.Halt();
+                TheCPU.Halt();
             }
         }
     }

--- a/Kernel/Kernel/Tasks/KernelTask.cs
+++ b/Kernel/Kernel/Tasks/KernelTask.cs
@@ -26,7 +26,7 @@
 
 //DFSC: Deferred System Calls
 //#define DSC_TRACE
-#define DFSC_TRACE
+//#define DFSC_TRACE
 //#define SYSCALLS_TRACE
 
 using Kernel.FOS_System.Collections;
@@ -348,6 +348,19 @@ namespace Kernel.Tasks
                     SystemCalls.SleepThread(50);
                 }
 
+                BasicConsole.WriteLine(" > Starting deferred file syscalls thread...");
+                DeferredFileSyscallsThread = ProcessManager.CurrentProcess.CreateThread(DeferredFileSyscallsThread_Main, "Deferred File Sys Calls");
+
+                while (!DeferredFileSyscalls_Ready)
+                {
+                    BasicConsole.WriteLine("Waiting on deferred file syscalls thread...");
+                    SystemCalls.SleepThread(50);
+                }
+
+                BasicConsole.WriteLine(" > Starting deferred file syscalls helper threads...");
+                ProcessManager.CurrentProcess.CreateThread(WaitForFileCmdPipes, "Deferred File Sys Calls : Wait For File Cmd Pipes");
+                ProcessManager.CurrentProcess.CreateThread(WaitForFileDataPipes, "Deferred File Sys Calls : Wait For File Data Pipes");
+
                 BasicConsole.WriteLine(" > Starting Idle process...");
                 Process IdleProcess1 = ProcessManager.CreateProcess(Tasks.IdleTask.Main, "Idle Task", false);
                 ProcessManager.RegisterProcess(IdleProcess1, Scheduler.Priority.ZeroTimed);
@@ -359,6 +372,9 @@ namespace Kernel.Tasks
                 //BasicConsole.WriteLine(" > Starting Debugger thread...");
                 //Debug.Debugger.MainThread = ProcessManager.CurrentProcess.CreateThread(Debug.Debugger.Main, "Debugger");
 #endif
+
+                BasicConsole.PrimaryOutputEnabled = false;
+                //BasicConsole.SecondaryOutputEnabled = false;
 
                 BasicConsole.WriteLine(" > Starting Window Manager...");
                 Process WindowManagerProcess = ProcessManager.CreateProcess(WindowManagerTask.Main, "Window Manager", false);
@@ -373,22 +389,6 @@ namespace Kernel.Tasks
                     SystemCalls.SleepThread(1000);
                 }
                 BasicConsole.WriteLine(" > Window Manager reported ready.");
-
-                BasicConsole.PrimaryOutputEnabled = false;
-                //BasicConsole.SecondaryOutputEnabled = false;
-
-                //BasicConsole.WriteLine(" > Starting deferred file syscalls thread...");
-                //DeferredFileSyscallsThread = ProcessManager.CurrentProcess.CreateThread(DeferredFileSyscallsThread_Main, "Deferred File Sys Calls");
-
-                //while (!DeferredFileSyscalls_Ready)
-                //{
-                //    BasicConsole.WriteLine("Waiting on deferred file syscalls thread...");
-                //    SystemCalls.SleepThread(50);
-                //}
-
-                //BasicConsole.WriteLine(" > Starting deferred file syscalls helper threads...");
-                //ProcessManager.CurrentProcess.CreateThread(WaitForFileCmdPipes, "Deferred File Sys Calls : Wait For File Cmd Pipes");
-                //ProcessManager.CurrentProcess.CreateThread(WaitForFileDataPipes, "Deferred File Sys Calls : Wait For File Data Pipes");
 
                 BasicConsole.WriteLine(" > Starting File Systems driver...");
                 Process FileSystemsProcess = ProcessManager.CreateProcess(Tasks.Driver.FileSystemsDriverTask.Main, "File Systems Driver", false);

--- a/Kernel/Kernel/Tasks/KernelTask.cs
+++ b/Kernel/Kernel/Tasks/KernelTask.cs
@@ -24,9 +24,10 @@
 // ------------------------------------------------------------------------------ //
 #endregion
 
-//DFSC: Deferred System Calls
+// DSC  : Deferred System Calls
+// DFSC : Deferred File System Calls
 //#define DSC_TRACE
-//#define DFSC_TRACE
+#define DFSC_TRACE
 //#define SYSCALLS_TRACE
 
 using Kernel.FOS_System.Collections;
@@ -73,15 +74,19 @@ namespace Kernel.Tasks
         private static bool DeferredSyscalls_Ready = false;
         [Drivers.Compiler.Attributes.Group(Name = "IsolatedKernel")]
         private static Thread DeferredSyscallsThread;
+        [Drivers.Compiler.Attributes.Group(Name = "IsolatedKernel")]
+        private static int DeferredSyscalls_QueuedSemaphoreId;
 
         [Drivers.Compiler.Attributes.Group(Name = "IsolatedKernel")]
-        private static Queue DeferredFileSyscallsInfo_Unqueued;
+        private static bool FilePipesReady = false;
         [Drivers.Compiler.Attributes.Group(Name = "IsolatedKernel")]
-        private static Queue DeferredFileSyscallsInfo_Queued;
+        private static Thread FilePipeInitialisationThread;
         [Drivers.Compiler.Attributes.Group(Name = "IsolatedKernel")]
-        private static bool DeferredFileSyscalls_Ready = false;
+        private static Thread FileSystemManagerInitialisationThread;
         [Drivers.Compiler.Attributes.Group(Name = "IsolatedKernel")]
-        private static Thread DeferredFileSyscallsThread;
+        private static int FilePipeAvailable_SemaphoreId;
+        [Drivers.Compiler.Attributes.Group(Name = "IsolatedKernel")]
+        private static int FileSystemManagerAvailable_SemaphoreId;
 
         [Drivers.Compiler.Attributes.Group(Name = "IsolatedKernel")]
         public static uint WindowManagerTask_ProcessId;
@@ -247,13 +252,7 @@ namespace Kernel.Tasks
             {
                 DeferredSyscallsInfo_Unqueued.Push(new DeferredSyscallInfo());
             }
-
-            DeferredFileSyscallsInfo_Unqueued = new Queue(256, false);
-            DeferredFileSyscallsInfo_Queued = new Queue(DeferredFileSyscallsInfo_Unqueued.Capacity, false);
-            for (int i = 0; i < DeferredFileSyscallsInfo_Unqueued.Capacity; i++)
-            {
-                DeferredFileSyscallsInfo_Unqueued.Push(new DeferredSyscallInfo());
-            }
+            DeferredSyscalls_QueuedSemaphoreId = ProcessManager.Semaphore_Allocate(-1, ProcessManager.KernelProcess);
 
             //TODO: These need registering via system calls and message or pipe interfaces created
             //      Really they shouldn't be initialised by Kernel Task nor used by Kernel/Debugger Tasks directly.
@@ -333,6 +332,9 @@ namespace Kernel.Tasks
 
                 //ProcessManager.CurrentProcess.OutputMemTrace = true;
 
+                //IMPORTANT NOTE: For now, all threads for the KernelProcess MUST be started BEFORE any/all
+                //                other processes
+
                 BasicConsole.WriteLine(" > Forcing initial GC cleanup...");
                 FOS_System.GC.Cleanup();
 
@@ -348,18 +350,19 @@ namespace Kernel.Tasks
                     SystemCalls.SleepThread(50);
                 }
 
-                BasicConsole.WriteLine(" > Starting deferred file syscalls thread...");
-                DeferredFileSyscallsThread = ProcessManager.CurrentProcess.CreateThread(DeferredFileSyscallsThread_Main, "Deferred File Sys Calls");
+                BasicConsole.WriteLine(" > Starting file pipe initialisation thread...");
+                FilePipeInitialisationThread = ProcessManager.CurrentProcess.CreateThread(FilePipeInitialisation_Main, "File Management : File Pipe Initialisation");
 
-                while (!DeferredFileSyscalls_Ready)
+                while (!FilePipesReady)
                 {
-                    BasicConsole.WriteLine("Waiting on deferred file syscalls thread...");
+                    BasicConsole.WriteLine("Waiting on file pipes to be ready...");
                     SystemCalls.SleepThread(50);
                 }
 
-                BasicConsole.WriteLine(" > Starting deferred file syscalls helper threads...");
-                ProcessManager.CurrentProcess.CreateThread(WaitForFileCmdPipes, "Deferred File Sys Calls : Wait For File Cmd Pipes");
-                ProcessManager.CurrentProcess.CreateThread(WaitForFileDataPipes, "Deferred File Sys Calls : Wait For File Data Pipes");
+                BasicConsole.WriteLine(" > Starting file system helper threads...");
+                ProcessManager.CurrentProcess.CreateThread(WaitForFileCmdPipes, "File Management : Wait For File Cmd Pipes");
+                ProcessManager.CurrentProcess.CreateThread(WaitForFileDataPipes, "File Management : Wait For File Data Pipes");
+                FileSystemManagerInitialisationThread = ProcessManager.CurrentProcess.CreateThread(FileSystemManagerInitialisation_Main, "File Management : File System Initialisation");
 
                 BasicConsole.WriteLine(" > Starting Idle process...");
                 Process IdleProcess1 = ProcessManager.CreateProcess(Tasks.IdleTask.Main, "Idle Task", false);
@@ -472,10 +475,7 @@ namespace Kernel.Tasks
             {
                 DeferredSyscalls_Ready = true;
 
-                if (DeferredSyscallsInfo_Queued.Count == 0)
-                {
-                    SystemCalls.SleepThread(SystemCalls.IndefiniteSleepThread);
-                }
+                ProcessManager.Semaphore_WaitCurrentThread(DeferredSyscalls_QueuedSemaphoreId);
 
                 while (DeferredSyscallsInfo_Queued.Count > 0)
                 {
@@ -648,6 +648,11 @@ namespace Kernel.Tasks
                         bool registered = Pipes.PipeManager.RegisterPipeOutpoint(CallerProcess.Id, (PipeClasses)Param1, (PipeSubclasses)Param2, (int)Param3, out outpoint);
                         if (registered)
                         {
+                            if (((PipeClasses)Param1) == PipeClasses.File && ((PipeSubclasses)Param2) == PipeSubclasses.File_Data_Out)
+                            {
+                                ProcessManager.Semaphore_Signal(FilePipeAvailable_SemaphoreId, ProcessManager.KernelProcess);
+                            }
+
                             result = SystemCallResults.OK;
                         }
                         else
@@ -1011,16 +1016,6 @@ namespace Kernel.Tasks
                         result = waitResult == -1 ? SystemCallResults.Fail : (waitResult == 1 ? SystemCallResults.OK : SystemCallResults.OK_NoWake);
                     }
                     break;
-                case SystemCallNumbers.SignalSemaphore:
-#if DSC_TRACE
-                    BasicConsole.WriteLine("DSC: Signal semaphore");
-#endif
-                    // Param1: Id
-                    {
-                        bool signalResult = ProcessManager.Semaphore_Signal((int)Param1, CallerProcess);
-                        result = signalResult ? SystemCallResults.OK : SystemCallResults.Fail;
-                    }
-                    break;
                 case SystemCallNumbers.RegisterDevice:
 #if DSC_TRACE
                     BasicConsole.WriteLine("DSC: Register device");
@@ -1106,6 +1101,12 @@ namespace Kernel.Tasks
 #if DSC_TRACE
                     BasicConsole.WriteLine("DSC: Release device - end");
 #endif
+                    break;
+                case SystemCallNumbers.InitFS:
+#if DFSC_TRACE
+                    BasicConsole.WriteLine("DFSC: Init FS");
+#endif
+                    ProcessManager.Semaphore_Signal(FileSystemManagerAvailable_SemaphoreId, ProcessManager.KernelProcess);
                     break;
                 default:
 //#if DSC_TRACE
@@ -1227,6 +1228,34 @@ namespace Kernel.Tasks
                 BasicConsole.WriteLine("KT File Management > Cannot get outpoints!");
             }
         }
+        private static void InitFileSystemManagers()
+        {
+            BasicConsole.WriteLine("KT File Management > Initialising file system managers...");
+            for (int i = 0; i < FileSystemManagers.Count; i++)
+            {
+                BasicConsole.WriteLine("KT File Management > Initialising file system manager...");
+
+                FileSystemManagerInfo info = (FileSystemManagerInfo)FileSystemManagers[i];
+
+                BasicConsole.WriteLine("KT File Management > Sending StatFS command...");
+                File_CmdOutpoint.Send_StatFS(info.CmdPipeId);
+                File_DataOutpoint.WriteString(info.DataOutPipeId, "\0");
+
+                BasicConsole.WriteLine("KT File Management > Reading mapping prefixes...");
+                info.MappingPrefixes = info.DataInPipe.ReadFSInfos(true);
+
+                BasicConsole.Write("KT > Got file system mappings: ");
+                for (int j = 0; j < info.MappingPrefixes.Length; j++)
+                {
+                    BasicConsole.Write(info.MappingPrefixes[j]);
+                    if (j < info.MappingPrefixes.Length - 1)
+                    {
+                        BasicConsole.Write(", ");
+                    }
+                }
+                BasicConsole.WriteLine();
+            }
+        }
         private static void WaitForFileCmdPipes()
         {
             while (!Terminating)
@@ -1249,28 +1278,7 @@ namespace Kernel.Tasks
                 SystemCalls.SignalSemaphore(File_DataOutPipesSemaphoreId);
             }
         }
-        private static void InitFileSystemManagers()
-        {
-            for (int i = 0; i < FileSystemManagers.Count; i++)
-            {
-                FileSystemManagerInfo info = (FileSystemManagerInfo)FileSystemManagers[i];
-                File_CmdOutpoint.Send_StatFS(info.CmdPipeId);
-                File_DataOutpoint.WriteString(info.DataOutPipeId, "");
-                info.MappingPrefixes = info.DataInPipe.ReadFSInfos(true);
-
-                BasicConsole.Write("KT > Got file system mappings: ");
-                for (int j = 0; j < info.MappingPrefixes.Length; i++)
-                {
-                    BasicConsole.Write(info.MappingPrefixes[i]);
-                    if (j < info.MappingPrefixes.Length - 1)
-                    {
-                        BasicConsole.Write(", ");
-                    }
-                }
-                BasicConsole.WriteLine();
-            }
-        }
-        public static void DeferredFileSyscallsThread_Main()
+        public static void FilePipeInitialisation_Main()
         {
             File_DataInpoints = new List();
             File_CmdOutPipes = new UInt32List();
@@ -1295,146 +1303,50 @@ namespace Kernel.Tasks
                 BasicConsole.WriteLine("Kernel Task > File Access > Failed to create a semaphore! (3)");
             }
 
-            DeferredFileSyscalls_Ready = true;
+            if (SystemCalls.CreateSemaphore(-1, out FilePipeAvailable_SemaphoreId) != SystemCallResults.OK)
+            {
+                BasicConsole.WriteLine("Kernel Task > File Access > Failed to create a semaphore! (4)");
+            }
 
-//            while (FileSystemManagers.Count == 0)
-//            {
-//                InitFilePipes();
-//                Thread.Sleep(5000);
-//            }
+            if (SystemCalls.CreateSemaphore(-1, out FileSystemManagerAvailable_SemaphoreId) != SystemCallResults.OK)
+            {
+                BasicConsole.WriteLine("Kernel Task > File Access > Failed to create a semaphore! (5)");
+            }
+
+            FilePipesReady = true;
 
             while (!Terminating)
             {
-//                DeferredFileSyscalls_Ready = true;
+                SystemCalls.WaitSemaphore(FilePipeAvailable_SemaphoreId);
 
-//                if (DeferredFileSyscallsInfo_Queued.Count == 0)
-//                {
-                    SystemCalls.SleepThread(SystemCalls.IndefiniteSleepThread);
-//                }
+                SystemCalls.SleepThread(50);
 
-//                while (DeferredFileSyscallsInfo_Queued.Count > 0)
-//                {
-//                    // Scheduler must be disabled during pop/push from circular buffer or we can
-//                    //  end up in an infinite lock. Consider what happens if a process invokes 
-//                    //  a deferred FileSystem call during the pop/push here and at the end of this loop.
-//#if DFSC_TRACE
-//                    BasicConsole.WriteLine("DFSC: Pausing scheduler...");
-//#endif
-//                    Scheduler.Disable(/*"DFSC 1"*/);
-//#if DFSC_TRACE
-//                    BasicConsole.WriteLine("DFSC: Popping queued info object...");
-//#endif
-//                    DeferredSyscallInfo info = (DeferredSyscallInfo)DeferredFileSyscallsInfo_Queued.Pop();
-//#if DFSC_TRACE
-//                    BasicConsole.WriteLine("DFSC: Resuming scheduler...");
-//#endif
-//                    Scheduler.Enable();
-
-//#if DFSC_TRACE
-//                    BasicConsole.WriteLine("DFSC: Getting process & thread...");
-//#endif
-//                    Process CallerProcess = ProcessManager.GetProcessById(info.ProcessId);
-//                    Thread CallerThread = ProcessManager.GetThreadById(info.ThreadId, CallerProcess);
-
-//#if DFSC_TRACE
-//                    BasicConsole.Write("DFSC: Process: ");
-//                    BasicConsole.WriteLine(CallerProcess.Name);
-//                    BasicConsole.Write("DFSC: Thread: ");
-//                    BasicConsole.WriteLine(CallerThread.Name);
-//#endif
-
-//                    ProcessManager.EnableKernelAccessToProcessMemory(CallerProcess);
-
-//#if DFSC_TRACE
-//                    BasicConsole.WriteLine("DFSC: Getting data...");
-//#endif
-//                    SystemCallNumbers FileSysCallNumber = (SystemCallNumbers)CallerThread.SysCallNumber;
-//                    uint Param1 = CallerThread.Param1;
-//                    uint Param2 = CallerThread.Param2;
-//                    uint Param3 = CallerThread.Param3;
-//                    uint Return2 = CallerThread.Return2;
-//                    uint Return3 = CallerThread.Return3;
-//                    uint Return4 = CallerThread.Return4;
-//#if DFSC_TRACE
-//                    BasicConsole.WriteLine("DFSC: Getting data done.");
-//#endif
-//                    ProcessManager.DisableKernelAccessToProcessMemory(CallerProcess);
-
-//#if DFSC_TRACE
-//                    BasicConsole.WriteLine("DFSC: Calling...");
-//#endif
-//                    SystemCallResults result = HandleDeferredFileSystemCall(
-//                        CallerProcess, CallerThread,
-//                        FileSysCallNumber, Param1, Param2, Param3,
-//                        ref Return2, ref Return3, ref Return4);
-
-//#if DFSC_TRACE
-//                    BasicConsole.WriteLine("DFSC: Ending call...");
-//#endif
-//                    if (result != SystemCallResults.Deferred)
-//                    {
-//                        EndDeferredFileSystemCall(CallerProcess, CallerThread, result, Return2, Return3, Return4);
-//                    }
-
-//#if DFSC_TRACE
-//                    BasicConsole.WriteLine("DFSC: Resetting info object...");
-//#endif
-//                    info.ProcessId = 0;
-//                    info.ThreadId = 0;
-
-//                    // See comment at top of loop for why this is necessary
-//#if DFSC_TRACE
-//                    BasicConsole.WriteLine("DFSC: Pausing scheduler...");
-//#endif
-//                    Scheduler.Disable(/*"DFSC 2"*/);
-//#if DFSC_TRACE
-//                    BasicConsole.WriteLine("DFSC: Queuing info object...");
-//#endif
-//                    DeferredFileSyscallsInfo_Unqueued.Push(info);
-//#if DFSC_TRACE
-//                    BasicConsole.WriteLine("DFSC: Resuming scheduler...");
-//#endif
-//                    Scheduler.Enable();
-//                }
+                try
+                {
+                    InitFilePipes();
+                }
+                catch
+                {
+                    BasicConsole.WriteLine("Error initialising file pipes!");
+                    BasicConsole.WriteLine(ExceptionMethods.CurrentException.Message);
+                }
             }
         }
-        public static unsafe SystemCallResults HandleDeferredFileSystemCall(
-            Process CallerProcess, Thread CallerThread,
-            SystemCallNumbers syscallNumber, uint Param1, uint Param2, uint Param3,
-            ref uint Return2, ref uint Return3, ref uint Return4)
+        public static void FileSystemManagerInitialisation_Main()
         {
-            SystemCallResults result = SystemCallResults.Unhandled;
-
-            switch (syscallNumber)
+            while (!Terminating)
             {
-                case SystemCallNumbers.InitFS:
-#if DFSC_TRACE
-                    BasicConsole.WriteLine("DFSC: Init FS");
-#endif
+                SystemCalls.WaitSemaphore(FileSystemManagerAvailable_SemaphoreId);
+
+                try
+                {
                     InitFileSystemManagers();
-                    break;
-                default:
-#if DFSC_TRACE
-                    BasicConsole.WriteLine("DFSC: Unrecognised call number.");
-                    BasicConsole.WriteLine((uint)syscallNumber);
-#endif
-                    break;
-            }
-
-            return result;
-        }
-        public static void EndDeferredFileSystemCall(Process CallerProcess, Thread CallerThread, SystemCallResults result, uint Return2, uint Return3, uint Return4)
-        {
-            ProcessManager.EnableKernelAccessToProcessMemory(CallerProcess);
-            CallerThread.Return1 = (uint)(result == SystemCallResults.OK_NoWake ? SystemCallResults.OK : result);
-            CallerThread.Return2 = Return2;
-            CallerThread.Return3 = Return3;
-            CallerThread.Return4 = Return4;
-            ProcessManager.DisableKernelAccessToProcessMemory(CallerProcess);
-
-            if (result != SystemCallResults.OK_NoWake)
-            {
-                CallerThread._Wake();
+                }
+                catch
+                {
+                    BasicConsole.WriteLine("Error initialising file system managers!");
+                    BasicConsole.WriteLine(ExceptionMethods.CurrentException.Message);
+                }
             }
         }
 
@@ -1473,36 +1385,19 @@ namespace Kernel.Tasks
 
             if (result == SystemCallResults.Deferred || result == SystemCallResults.Deferred_PermitActions)
             {
-                if (syscallNumber >= (int)SystemCallNumbers.StatFS && syscallNumber <= (int)SystemCallNumbers.SetWorkingDir)
-                {
-                    BasicConsole.WriteLine("Deferring file syscall...");
-                    //BasicConsole.WriteLine("Popping unqueued info object...");
-                    DeferredSyscallInfo info = (DeferredSyscallInfo)DeferredFileSyscallsInfo_Unqueued.Pop();
-                    //BasicConsole.WriteLine("Setting info...");
-                    info.ProcessId = callerProcessId;
-                    info.ThreadId = callerThreadId;
+                //BasicConsole.WriteLine("Deferring syscall...");
+                //BasicConsole.WriteLine("Popping unqueued info object...");
+                DeferredSyscallInfo info = (DeferredSyscallInfo)DeferredSyscallsInfo_Unqueued.Pop();
+                //BasicConsole.WriteLine("Setting info...");
+                info.ProcessId = callerProcessId;
+                info.ThreadId = callerThreadId;
 
-                    //BasicConsole.WriteLine("Queuing info object...");
-                    DeferredFileSyscallsInfo_Queued.Push(info);
+                //BasicConsole.WriteLine("Queuing info object...");
+                DeferredSyscallsInfo_Queued.Push(info);
 
-                    //BasicConsole.WriteLine("Waking deferred file syscalls thread...");
-                    DeferredFileSyscallsThread._Wake();
-                }
-                else
-                {
-                    //BasicConsole.WriteLine("Deferring syscall...");
-                    //BasicConsole.WriteLine("Popping unqueued info object...");
-                    DeferredSyscallInfo info = (DeferredSyscallInfo)DeferredSyscallsInfo_Unqueued.Pop();
-                    //BasicConsole.WriteLine("Setting info...");
-                    info.ProcessId = callerProcessId;
-                    info.ThreadId = callerThreadId;
-
-                    //BasicConsole.WriteLine("Queuing info object...");
-                    DeferredSyscallsInfo_Queued.Push(info);
-
-                    //BasicConsole.WriteLine("Waking deferred syscalls thread...");
-                    DeferredSyscallsThread._Wake();
-                }
+                //BasicConsole.WriteLine("Signaling deferred syscalls thread...");
+                ProcessManager.Semaphore_Signal(DeferredSyscalls_QueuedSemaphoreId, ProcessManager.KernelProcess);
+                //BasicConsole.WriteLine("Signaled.");
             }
 
             return (int)result;
@@ -1849,7 +1744,11 @@ namespace Kernel.Tasks
 #if SYSCALLS_TRACE
                     BasicConsole.WriteLine("System call : Signal semaphore");
 #endif
-                    result = SystemCallResults.Deferred;
+                    // Param1: Id
+                    {
+                        bool signalResult = ProcessManager.Semaphore_Signal((int)param1, ProcessManager.GetProcessById(callerProcessId));
+                        result = signalResult ? SystemCallResults.OK : SystemCallResults.Fail;
+                    }
                     break;
                 case SystemCallNumbers.RegisterDevice:
 #if SYSCALLS_TRACE
@@ -2156,17 +2055,6 @@ namespace Kernel.Tasks
             {
                 keyboard.HandleScancode(ScanCode);
             }
-        }
-    }
-
-    public class TestComparable : FOS_System.Collections.Comparable
-    {
-        public TestComparable()
-        {
-        }
-        public TestComparable(int key)
-             : base(key)
-        {
         }
     }
 }

--- a/Kernel/Kernel/Tasks/WindowManagerTask.cs
+++ b/Kernel/Kernel/Tasks/WindowManagerTask.cs
@@ -111,7 +111,7 @@ namespace Kernel.Tasks
             //BasicConsole.Write("WM > Test thread id: ");
             //BasicConsole.WriteLine(TestThreadId);
 
-            BasicConsole.Write("WM > Register syscall handlers");
+            BasicConsole.WriteLine("WM > Register syscall handlers");
             SystemCalls.RegisterSyscallHandler(SystemCallNumbers.RegisterPipeOutpoint, SyscallHandler);
             SystemCalls.RegisterSyscallHandler(SystemCallNumbers.AcceptPages);
             
@@ -310,13 +310,13 @@ namespace Kernel.Tasks
             {
                 case SystemCallNumbers.RegisterPipeOutpoint:
                     {
-                        BasicConsole.WriteLine("WM > IH > Actioning Register Pipe Outpoint system call...");
+                        //BasicConsole.WriteLine("WM > IH > Actioning Register Pipe Outpoint system call...");
                         PipeClasses Class = (PipeClasses)param1;
                         PipeSubclasses Subclass = (PipeSubclasses)param2;
                         if (Class == PipeClasses.Standard &&
                             Subclass == PipeSubclasses.Standard_Out)
                         {
-                            BasicConsole.WriteLine("WM > IH > Register Pipe Outpoint has desired pipe class and subclass.");
+                            //BasicConsole.WriteLine("WM > IH > Register Pipe Outpoint has desired pipe class and subclass.");
                             result = SystemCallResults.RequestAction_SignalSemaphore;
                             Return2 = (uint)NewOutpointAvailable_SemaphoreId;
                         }

--- a/Kernel/Kernel/Tasks/WindowManagerTask.cs
+++ b/Kernel/Kernel/Tasks/WindowManagerTask.cs
@@ -53,9 +53,9 @@ namespace Kernel.Tasks
         /// </remarks>
         private static uint MainThreadId = 1;
         private static uint GCThreadId;
-        private static uint InputProcessingThreadId;
-        private static bool InputProcessingThreadAwake = false;
-        private static uint OutputProcessingThreadId;
+        private static int NewOutpointAvailable_SemaphoreId;
+        private static int NewPipeConnected_SemaphoreId;
+        private static int NewClientReady_SemaphoreId;
 
         public static bool Ready
         {
@@ -80,7 +80,21 @@ namespace Kernel.Tasks
             // Initialise connected pipes list
             ConnectedPipes = new List();
 
+            if (SystemCalls.CreateSemaphore(-1, out NewOutpointAvailable_SemaphoreId) != SystemCallResults.OK)
+            {
+                BasicConsole.WriteLine("WM > Failed to create a semaphore! (1)");
+            }
+            if (SystemCalls.CreateSemaphore(-1, out NewPipeConnected_SemaphoreId) != SystemCallResults.OK)
+            {
+                BasicConsole.WriteLine("WM > Failed to create a semaphore! (2)");
+            }
+            if (SystemCalls.CreateSemaphore(-1, out NewClientReady_SemaphoreId) != SystemCallResults.OK)
+            {
+                BasicConsole.WriteLine("WM > Failed to create a semaphore! (3)");
+            }
+
             // Start thread for handling background input processing
+            uint InputProcessingThreadId;
             if (SystemCalls.StartThread(InputProcessing, out InputProcessingThreadId) != SystemCallResults.OK)
             {
                 BasicConsole.WriteLine("Window Manager: InputProcessing thread failed to create!");
@@ -102,6 +116,7 @@ namespace Kernel.Tasks
             SystemCalls.RegisterSyscallHandler(SystemCallNumbers.AcceptPages);
             
             // Start thread for handling background output processing
+            uint OutputProcessingThreadId;
             if (SystemCalls.StartThread(OutputProcessing, out OutputProcessingThreadId) != SystemCallResults.OK)
             {
                 BasicConsole.WriteLine("Window Manager: OutputProcessing thread failed to create!");
@@ -115,7 +130,7 @@ namespace Kernel.Tasks
             BasicConsole.WriteLine("WM > Wait for pipe to be created");
             // Wait for pipe to be created
             ready_count++;
-            SystemCalls.SleepThread(SystemCalls.IndefiniteSleepThread);
+            SystemCalls.WaitSemaphore(NewClientReady_SemaphoreId);
 
             PipeInfo CurrentPipeInfo = null;
 
@@ -201,12 +216,8 @@ namespace Kernel.Tasks
             {
                 //BasicConsole.WriteLine("WM > IP : (0)");
 
-                if (!InputProcessingThreadAwake)
-                {
-                    SystemCalls.SleepThread(10000);
-                }
-                InputProcessingThreadAwake = false;
-
+                SystemCalls.WaitSemaphore(NewOutpointAvailable_SemaphoreId);
+                
                 //BasicConsole.WriteLine("WM > InputProcessing thread running...");
 
                 int numOutpoints;
@@ -245,7 +256,7 @@ namespace Kernel.Tasks
                                 }
                             }
 
-                            if(!PipeExists)
+                            if (!PipeExists)
                             {
                                 try
                                 {
@@ -263,8 +274,8 @@ namespace Kernel.Tasks
                                         CurrentPipeIdx = 0;
                                         CurrentPipeIndex_Changed = true;
 
-                                        SystemCalls.WakeThread(MainThreadId);
-                                        SystemCalls.WakeThread(OutputProcessingThreadId);
+                                        SystemCalls.SignalSemaphore(NewClientReady_SemaphoreId);
+                                        SystemCalls.SignalSemaphore(NewPipeConnected_SemaphoreId);
                                     }
 
                                     //BasicConsole.WriteLine("WM > IP : (8)");
@@ -306,9 +317,8 @@ namespace Kernel.Tasks
                             Subclass == PipeSubclasses.Standard_Out)
                         {
                             BasicConsole.WriteLine("WM > IH > Register Pipe Outpoint has desired pipe class and subclass.");
-                            result = SystemCallResults.RequestAction_WakeThread;
-                            Return2 = InputProcessingThreadId;
-                            InputProcessingThreadAwake = true;
+                            result = SystemCallResults.RequestAction_SignalSemaphore;
+                            Return2 = (uint)NewOutpointAvailable_SemaphoreId;
                         }
                     }
                     break;
@@ -331,7 +341,7 @@ namespace Kernel.Tasks
             ready_count++;
 
             // Wait for pipe to be created
-            SystemCalls.SleepThread(SystemCalls.IndefiniteSleepThread);
+            SystemCalls.WaitSemaphore(NewPipeConnected_SemaphoreId);
 
             PipeInfo CurrentPipeInfo = ((PipeInfo)ConnectedPipes[CurrentPipeIdx]);
 
@@ -341,11 +351,11 @@ namespace Kernel.Tasks
                 {
                     //BasicConsole.WriteLine("WM > OP : (0)");
 
-                    bool AltPressed = Keyboard.Default.AltPressed;
                     uint Scancode;
                     bool GotScancode = Keyboard.Default.GetScancode(out Scancode);
                     if (GotScancode)
                     {
+                        bool AltPressed = Keyboard.Default.AltPressed;
                         //BasicConsole.WriteLine("WM > OP : (1)");
 
                         KeyboardKey Key;

--- a/Kernel/Libraries/Kernel.FOS_System.IO/FileSystemClient.cs
+++ b/Kernel/Libraries/Kernel.FOS_System.IO/FileSystemClient.cs
@@ -64,6 +64,7 @@ namespace Kernel.FOS_System.IO
                 {
                     BasicConsole.WriteLine("File System Client > Error processing command!");
                     BasicConsole.WriteLine(ExceptionMethods.CurrentException.Message);
+                    SystemCalls.SleepThread(1000);
                 }
             }
         }

--- a/Kernel/Libraries/Kernel.FOS_System/ByteConverter.cs
+++ b/Kernel/Libraries/Kernel.FOS_System/ByteConverter.cs
@@ -133,6 +133,12 @@ namespace Kernel.FOS_System
         [Drivers.Compiler.Attributes.NoDebug]
         public static FOS_System.String GetASCIIStringFromASCII(byte[] n, UInt32 aStart, UInt32 aCharCount)
         {
+            // Shortcut all of the effort below
+            if (aCharCount == 0 || n[0] == 0)
+            {
+                return FOS_System.String.New(0);
+            }
+
             {
                 uint maxExtent = (aCharCount + aStart);
                 uint i = aStart;
@@ -178,6 +184,12 @@ namespace Kernel.FOS_System
         [Drivers.Compiler.Attributes.NoDebug]
         public static unsafe FOS_System.String GetASCIIStringFromASCII(byte* n, UInt32 aStart, UInt32 aCharCount)
         {
+            // Shortcut all of the effort below
+            if (aCharCount == 0 || n[0] == 0)
+            {
+                return FOS_System.String.New(0);
+            }
+
             {
                 uint maxExtent = (aCharCount + aStart);
                 uint i = aStart;
@@ -228,6 +240,12 @@ namespace Kernel.FOS_System
         {
             //If you change this method, change the pointer version below too.
 
+            // Shortcut all of the effort below
+            if (aCharCount == 0 || (n[0] == 0 && n[1] == 0))
+            {
+                return FOS_System.String.New(0);
+            }
+
             {
                 uint maxExtent = (aCharCount * 2) + aStart;
                 uint i = aStart;
@@ -275,6 +293,12 @@ namespace Kernel.FOS_System
         public unsafe static FOS_System.String GetASCIIStringFromUTF16(byte* n, UInt32 aStart, UInt32 aCharCount)
         {
             //If you change this method, change the array version above too.
+
+            // Shortcut all of the effort below
+            if (aCharCount == 0 || (n[0] == 0 && n[1] == 0))
+            {
+                return FOS_System.String.New(0);
+            }
 
             {
                 uint maxExtent = (aCharCount * 2) + aStart;

--- a/Kernel/Libraries/Kernel.FOS_System/Heap.cs
+++ b/Kernel/Libraries/Kernel.FOS_System/Heap.cs
@@ -675,16 +675,16 @@ namespace Kernel.FOS_System
                 {
                     BasicConsole.WriteLine("New heap NOT created (via expand)!");
                 }
-                else
-                {
-                    BasicConsole.WriteLine("New heap created (via expand)!");
-                    if (print)
-                    {
-                        BasicConsole.Write("New heap size: ");
-                        BasicConsole.Write(GetTotalMem() / 1024);
-                        BasicConsole.WriteLine("KiB");
-                    }
-                }
+                //else
+                //{
+                //    BasicConsole.WriteLine("New heap created (via expand)!");
+                //    if (print)
+                //    {
+                //        BasicConsole.Write("New heap size: ");
+                //        BasicConsole.Write(GetTotalMem() / 1024);
+                //        BasicConsole.WriteLine("KiB");
+                //    }
+                //}
             }
             else
             {
@@ -696,16 +696,16 @@ namespace Kernel.FOS_System
                     {
                         BasicConsole.WriteLine("Couldn't expand heap!");
                     }
-                    else
-                    {
-                        BasicConsole.WriteLine("Heap expanded successfully.");
-                        if (print)
-                        {
-                            BasicConsole.Write("New heap size: ");
-                            BasicConsole.Write(GetTotalMem() / 1024);
-                            BasicConsole.WriteLine("KiB");
-                        }
-                    }
+                    //else
+                    //{
+                    //    BasicConsole.WriteLine("Heap expanded successfully.");
+                    //    if (print)
+                    //    {
+                    //        BasicConsole.Write("New heap size: ");
+                    //        BasicConsole.Write(GetTotalMem() / 1024);
+                    //        BasicConsole.WriteLine("KiB");
+                    //    }
+                    //}
                     oldFBlock->expanding = false;
                 }
             }

--- a/Kernel/Libraries/Kernel.FOS_System/Processes/SystemCalls_Enums.cs
+++ b/Kernel/Libraries/Kernel.FOS_System/Processes/SystemCalls_Enums.cs
@@ -262,8 +262,21 @@ namespace Kernel.FOS_System.Processes
         /// </remarks>
         RequestAction_WakeThread = 0xC6DEC6DE,
         /// <summary>
+        /// The system call was unhandled but the handler method is requesting a semaphore be signalled.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// This is only supposed to be seen within the core OS. A caller should never see this value.
+        /// </para>
+        /// <para>
+        /// This is used so a system call can be used as a notification to a process. A method returning
+        /// this cannot also handle the system call.
+        /// </para>
+        /// </remarks>
+        RequestAction_SignalSemaphore = 0xC7DEC7DE,
+        /// <summary>
         /// The system call was handled successfully but the thread should not be woken.
         /// </summary>
-        OK_NoWake = 0xC7DEC7DE,
+        OK_NoWake = 0xC8DEC8DE,
     }
 }

--- a/Kernel/Libraries/Kernel.Hardware/Controllers/StorageController.cs
+++ b/Kernel/Libraries/Kernel.Hardware/Controllers/StorageController.cs
@@ -156,9 +156,9 @@ namespace Kernel.Hardware.Controllers
                             {
                                 unsafe
                                 {
-                                    BasicConsole.WriteLine("Storage Controller > Wait for command from client...");
+                                    //BasicConsole.WriteLine("Storage Controller > Wait for command from client...");
                                     StoragePipeCommand* CommandPtr = CmdInpoint.Read();
-                                    BasicConsole.WriteLine("Storage Controller > Command received from client: " + (String)CommandPtr->Command);
+                                    //BasicConsole.WriteLine("Storage Controller > Command received from client: " + (String)CommandPtr->Command);
 
                                     switch ((StorageCommands)CommandPtr->Command)
                                     {
@@ -491,13 +491,13 @@ namespace Kernel.Hardware.Controllers
                                 ACommand = (DiskCommand)TheInfo.CommandQueue.Pop();
                                 SystemCalls.SignalSemaphore(TheInfo.CommandQueueAccessSemaphoreId);
 
-                                BasicConsole.WriteLine("Storage controller > Disk command received: " + (String)(uint)ACommand.Command);
+                                //BasicConsole.WriteLine("Storage controller > Disk command received: " + (String)(uint)ACommand.Command);
 
                                 switch(ACommand.Command)
                                 {
                                     case DiskCommands.Read:
                                         {
-                                            BasicConsole.WriteLine("Storage controller > Reading " + (String)ACommand.BlockCount + " blocks from " + (String)ACommand.BlockNo + " blocks offset.");
+                                            //BasicConsole.WriteLine("Storage controller > Reading " + (String)ACommand.BlockCount + " blocks from " + (String)ACommand.BlockNo + " blocks offset.");
                                             byte[] data = TheInfo.TheDevice.NewBlockArray(ACommand.BlockCount);
                                             TheInfo.TheDevice.ReadBlock(ACommand.BlockNo, ACommand.BlockCount, data);
                                             //BasicConsole.WriteLine("Data read (non-zero only): ");

--- a/Kernel/Libraries/Kernel.Hardware/Keyboards/PS2.cs
+++ b/Kernel/Libraries/Kernel.Hardware/Keyboards/PS2.cs
@@ -175,7 +175,10 @@ namespace Kernel.Hardware.Keyboards
         /// </summary>
         public static void Clean()
         {
-            ThePS2?.Disable();
+            if (ThePS2 != null)
+            {
+                ThePS2.Disable();
+            }
         }
     }
 }

--- a/Kernel/Libraries/Kernel.Hardware/Pipes/BasicInpoint.cs
+++ b/Kernel/Libraries/Kernel.Hardware/Pipes/BasicInpoint.cs
@@ -178,11 +178,11 @@ namespace Kernel.Pipes
                             //BasicConsole.WriteLine("BasicInPipe > ReadPipe: Failed!");
                             if (Blocking)
                             {
-                                ExceptionMethods.Throw(new Exceptions.RWFailedException("BasicInPipe : Write Pipe unexpected failed! (Blocking call)"));
+                                ExceptionMethods.Throw(new Exceptions.RWFailedException("BasicInPipe : Read Pipe unexpected failed! (Blocking call)"));
                             }
                             else
                             {
-                                ExceptionMethods.Throw(new Exceptions.RWFailedException("BasicInPipe : Write Pipe failed. (Non-blocking call)"));
+                                ExceptionMethods.Throw(new Exceptions.RWFailedException("BasicInPipe : Read Pipe failed. (Non-blocking call)"));
                             }
                             break;
                         case SystemCallResults.OK:

--- a/Kernel/Libraries/Kernel.Hardware/Pipes/BasicOutpoint.cs
+++ b/Kernel/Libraries/Kernel.Hardware/Pipes/BasicOutpoint.cs
@@ -114,11 +114,12 @@ namespace Kernel.Pipes
                         ExceptionMethods.Throw(new FOS_System.Exceptions.ArgumentException("BasicOutPipe : Wait On Pipe Create failed!"));
                         break;
                     case SystemCallResults.OK:
+                        aPipeId = request->Result.Id;
+                        InProcessId = request->Result.InpointProcessId;
+
                         //BasicConsole.WriteLine("BasicOutPipe > WaitOnPipeCreate: Succeeded.");
                         //BasicConsole.Write("BasicOutPipe > New pipe id: ");
                         //BasicConsole.WriteLine(aPipeId);
-                        aPipeId = request->Result.Id;
-                        InProcessId = request->Result.InpointProcessId;
                         break;
                     default:
                         //BasicConsole.WriteLine("BasicOutPipe > WaitOnPipeCreate: Unexpected system call result!");

--- a/Kernel/Libraries/Kernel.Hardware/Pipes/File/FileDataInpoint.cs
+++ b/Kernel/Libraries/Kernel.Hardware/Pipes/File/FileDataInpoint.cs
@@ -71,13 +71,27 @@ namespace Kernel.Pipes.File
                 for (int i = 0; i < Count; i++)
                 {
                     bytesRead = base.Read(ReadBuffer, 0, sizeof(FilePipeDataFSInfo), blocking);
+
                     if (bytesRead <= 0)
                     {
                         BasicConsole.WriteLine("FileDataInpoint : Error reading file system infos! Reading file system info data returned zero (or negative) byte count.");
                     }
                     else
                     {
-                        result[i] = ByteConverter.GetASCIIStringFromASCII(ReadBuffer, 0, 10);
+                        int charCount = 0;
+                        for (; charCount < 10; charCount++)
+                        {
+                            if (DataPtr->Prefix[charCount] == '\0')
+                            {
+                                break;
+                            }
+                        }
+
+                        result[i] = FOS_System.String.New(charCount);
+                        for (int j = 0; j < charCount; j++)
+                        {
+                            result[i][j] = DataPtr->Prefix[j];
+                        }
                     }
                 }
                 return result;
@@ -92,12 +106,7 @@ namespace Kernel.Pipes.File
             int bytesRead = base.Read(ReadBuffer, 0, sizeof(FilePipeDataHeader), blocking);
             if (bytesRead > 0)
             {
-                uint Count = ByteConverter.ToUInt32(ReadBuffer, 0);
-                if (Count != bytesRead - 4)
-                {
-                    BasicConsole.WriteLine("FileDataInpoint.ReadString > Error! Count inconsistent with bytes read.");
-                }
-                return ByteConverter.GetASCIIStringFromASCII(ReadBuffer, 4, Count);
+                return ByteConverter.GetASCIIStringFromASCII(ReadBuffer, 0, (uint)bytesRead);
             }
             else
             {

--- a/Kernel/Libraries/Kernel.Hardware/Processes/ProcessManager.cs
+++ b/Kernel/Libraries/Kernel.Hardware/Processes/ProcessManager.cs
@@ -24,7 +24,7 @@
 // ------------------------------------------------------------------------------ //
 #endregion
 
-#define PROCESSMANAGER_TRACE
+//#define PROCESSMANAGER_TRACE
 //#define PROCESSMANAGER_SWITCH_TRACE
 //#define PROCESSMANAGER_KERNEL_ACCESS_TRACE
 

--- a/Kernel/Libraries/Kernel.Hardware/Processes/ProcessManager.cs
+++ b/Kernel/Libraries/Kernel.Hardware/Processes/ProcessManager.cs
@@ -498,7 +498,7 @@ namespace Kernel.Hardware.Processes
             }
         }
 
-        public static bool WakeProcess(uint processId, uint threadId)
+        public static bool WakeThread(uint processId, uint threadId)
         {
             return WakeThread(GetProcessById(processId), threadId);
         }
@@ -554,6 +554,15 @@ namespace Kernel.Hardware.Processes
                 return true;
             }
             return false;
+        }
+        public static int Semaphore_WaitCurrentThread(int id)
+        {
+            if (Semaphore_VerifyOwner(id, CurrentProcess))
+            {
+                ((Semaphore)Semaphores[id]).Wait();
+                return 1;
+            }
+            return -1;
         }
         public static int Semaphore_Wait(int id, Process aProcess, Thread aThread)
         {

--- a/Kernel/Libraries/Kernel.Hardware/Processes/Scheduler.cs
+++ b/Kernel/Libraries/Kernel.Hardware/Processes/Scheduler.cs
@@ -363,9 +363,9 @@ namespace Kernel.Hardware.Processes
 
             while (ActiveQueue.Count == 0)
             {
-                //#if SCHEDULER_HANDLER_TRACE
-                BasicConsole.WriteLine("WARNING: Scheduler preventing infinite loop by early-updating sleeping threads.");
-                //#endif
+#if SCHEDULER_HANDLER_TRACE || SCHEDULER_HANDLER_MIN_TRACE
+                //BasicConsole.WriteLine("WARNING: Scheduler preventing infinite loop by early-updating sleeping threads.");
+#endif
                 UpdateInactiveThreads();
             }
 

--- a/Kernel/Libraries/Kernel.Hardware/Processes/SystemCalls_Handlers.cs
+++ b/Kernel/Libraries/Kernel.Hardware/Processes/SystemCalls_Handlers.cs
@@ -115,6 +115,14 @@ namespace Kernel.Hardware.Processes
                             ProcessManager.WakeThread(handlerProcess, TempReturn2);
                             tempResult = SystemCallResults.Unhandled;
                         }
+                        else if (tempResult == SystemCallResults.RequestAction_SignalSemaphore)
+                        {
+#if SYSCALLS_TRACE
+                            BasicConsole.WriteLine("System calls : Performing action - signal semaphore");
+#endif
+                            ProcessManager.Semaphore_Signal((int)TempReturn2, handlerProcess);
+                            tempResult = SystemCallResults.Unhandled;
+                        }
 
                         if (tempResult != SystemCallResults.Unhandled && !PermitActionResulted)
                         {

--- a/Kernel/Libraries/Kernel.Hardware/Processes/Thread.cs
+++ b/Kernel/Libraries/Kernel.Hardware/Processes/Thread.cs
@@ -182,7 +182,7 @@ namespace Kernel.Hardware.Processes
             }
         }
 
-        public Thread(Process AnOwner, ThreadStartPoint StartPoint, uint AnId, bool UserMode, FOS_System.String AName)
+        public Thread(Process AnOwner, ThreadStartPoint StartPoint, uint AnId, bool UserMode, FOS_System.String AName, out void* ThreadStackTopPAddr, out void* KernelStackTopPAddr)
         {
 #if THREAD_TRACE
             BasicConsole.WriteLine("Constructing thread object...");
@@ -216,17 +216,17 @@ namespace Kernel.Hardware.Processes
                 Hardware.VirtMemManager.MapFreePage(
                 UserMode ? Hardware.VirtMem.VirtMemImpl.PageFlags.None :
                            Hardware.VirtMem.VirtMemImpl.PageFlags.KernelOnly)*/ + KernelStackTopOffset; //4KiB, page-aligned
-            
+            KernelStackTopPAddr = VirtMemManager.GetPhysicalAddress(State->KernelStackTop - KernelStackTopOffset);
+
             // Allocate free memory for the user stack for this thread
             //  Used by this thread in normal execution
 #if THREAD_TRACE
             BasicConsole.WriteLine("Mapping thread stack page...");
 #endif
             State->UserMode = UserMode;
-            void* unusedPAddr;
             State->ThreadStackTop = (byte*)Hardware.VirtMemManager.MapFreePage(
                 UserMode ? Hardware.VirtMem.VirtMemImpl.PageFlags.None :
-                           Hardware.VirtMem.VirtMemImpl.PageFlags.KernelOnly, out unusedPAddr) + ThreadStackTopOffset; //4KiB, page-aligned
+                           Hardware.VirtMem.VirtMemImpl.PageFlags.KernelOnly, out ThreadStackTopPAddr) + ThreadStackTopOffset; //4KiB, page-aligned
             
             // Set ESP to the top of the stack - 4 byte aligned, high address since x86 stack works
             //  downwards


### PR DESCRIPTION
Changes associated with getting File Systems Initialisation working (i.e. up to the point where the kernel can get a list of file system mappings). 

Significant changes:
- There is no separate Deferred File System Calls thread now. This was a bad idea because EnableKernelAccessToProcessMemory relies on only one thread within the Kernel using it! (I.e. only enabling access to one other process at a time).
- Window Manager now uses semaphores instead of a hacky system of using sleep(indefinite)/wake which was a legacy from before semaphore were working properly.

Key bug fixes:
- Kernel threads for file systems are now initialised before any/all other processes. Kernel Process' threads need to be initialised before any/all other processes at the moment. This will be fixed in the near future.
- FileDataInpoint.ReadFSInfos misinterpreted the incoming data as entirely ASCII instead of doing proper struct/char array to String conversion.

Other changes:
- Completed TODO for thread creation within Process.CreateThread. It no longer relies on disabling the scheduler. The correct physical addresses are now returned by the Thread constructor directly.
- SignalSemaphore is no longer a deferred system call. This is sort of an experiment because signalling a semaphore shouldn't cause the ref count of anything to hit zero, so it should be fine.
- Exceptions thrown within ISRs / IRQs will now be handled cleanly rather than bringing down the whole system.
- Removed use of "?." (null conditional) operator because it's new in VS2015 so breaks VS2013 support.
