### PR TITLE
Fix V3003

### DIFF
--- a/Kernel/Libraries/Kernel.PCI/PCIDevice.cs
+++ b/Kernel/Libraries/Kernel.PCI/PCIDevice.cs
@@ -653,7 +653,7 @@ namespace Kernel.PCI
                         {
                             return "SERCOS interface";
                         }
-                        else if (device.Subclass == 0x03)
+                        else if (device.Subclass == 0x09)
                         {
                             return "CANBUS";
                         }


### PR DESCRIPTION
Hello! I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warning: 

- V3003 The use of 'if (A) {...} else if (A) {...}' pattern was detected. There is a probability of logical error presence. Check lines: 620, 656. Kernel.PCI PCIDevice.cs 620
